### PR TITLE
Increase robustness in the face of partial failures, and improve error logging

### DIFF
--- a/HTML5-frontend/Makefile.am
+++ b/HTML5-frontend/Makefile.am
@@ -18,7 +18,7 @@ TEMPDIRS = dist
 
 ndtdir = $(prefix)/ndt
 
-nobase_ndt_DATA = jquery-1.4.4.min.js ie.css style.css gauge.min.js widget.html \
+nobase_ndt_DATA = jquery-1.12.1.min.js ie.css style.css gauge.min.js widget.html \
 	   images/mlab-logo.png images/mlab-logo-small.png script.js \
            fonts/digital-7-mono.ttf fonts/League_Gothic.otf \
            fonts/League_Gothic.eot embed.html ndt-wrapper.js ndt-wrapper-ww.js ndt-browser-client.js

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -108,7 +108,7 @@ endif
 web100srv_SOURCES = web100srv.c web100-util.c web100-pcap.c web100-admin.c runningtest.c \
                     network.c usage.c utils.c mrange.c logging.c testoptions.c ndtptestconstants.c \
                     protocol.c test_sfw_srv.c test_meta_srv.c ndt_odbc.c strlutils.c heuristics.c \
-                    test_c2s_srv.c test_s2c_srv.c test_mid_srv.c jsonutils.c websocket.c
+                    test_c2s_srv.c test_s2c_srv.c test_mid_srv.c testutils.c jsonutils.c websocket.c
 web100srv_LDFLAGS = $(NDTLDFLAGS) $(I2UTILLDFLAGS)
 web100srv_LDADD = $(NDTLIBS) $(I2UTILLIBS) $(I2UTILLIBDEPS) -lpthread $(ZLIB) $(JSONLIB) $(OPENSSL_LDFLAGS) $(OPENSSL_LIBS)
 web100srv_CPPFLAGS ='-DBASEDIR="$(ndtdir)"' -DFORCE_WEB100 $(OPENSSL_INCLUDES)
@@ -130,8 +130,8 @@ web100_websocket_unit_tests_DEPENDENCIES = $(I2UTILLIBDEPS)
 web100_testoptions_unit_tests_SOURCES = testoptions_unit_tests.c testoptions.c unit_testing.c \
                                  heuristics.c jsonutils.c logging.c mrange.c ndt_odbc.c ndtptestconstants.c \
                                  network.c protocol.c runningtest.c strlutils.c test_c2s_srv.c test_meta_srv.c \
-                                 test_mid_srv.c test_s2c_srv.c test_sfw_srv.c utils.c web100-pcap.c web100-util.c \
-                                 web100srv.c websocket.c
+                                 test_mid_srv.c test_s2c_srv.c test_sfw_srv.c testutils.c utils.c web100-pcap.c \
+                                 web100-util.c web100srv.c websocket.c
 web100_testoptions_unit_tests_LDFLAGS = $(NDTLDFLAGS) $(I2UTILLDFLAGS)
 web100_testoptions_unit_tests_LDADD = $(NDTLIBS) $(I2UTILLIBS) $(I2UTILLIBDEPS) -lpthread $(ZLIB) $(JSONLIB) $(OPENSSL_LDFLAGS) $(OPENSSL_LIBS)
 web100_testoptions_unit_tests_CPPFLAGS ='-DBASEDIR="$(ndtdir)"' -DFORCE_WEB100 -DUSE_WEB100SRV_ONLY_AS_LIBRARY -Wall -Wno-unused-variable -Wno-unused-function $(OPENSSL_INCLUDES)
@@ -140,7 +140,7 @@ web100_testoptions_unit_tests_DEPENDENCIES = $(I2UTILLIBDEPS)
 web10gsrv_SOURCES = web100srv.c web100-util.c web100-pcap.c web100-admin.c runningtest.c \
 		    network.c usage.c utils.c mrange.c logging.c testoptions.c ndtptestconstants.c \
 		    protocol.c test_sfw_srv.c test_meta_srv.c ndt_odbc.c strlutils.c heuristics.c \
-		    test_c2s_srv.c test_s2c_srv.c test_mid_srv.c web10g-util.c jsonutils.c websocket.c
+		    test_c2s_srv.c test_s2c_srv.c test_mid_srv.c testutils.c web10g-util.c jsonutils.c websocket.c
 web10gsrv_LDFLAGS = $(NDTLDFLAGS) $(I2UTILLDFLAGS)
 web10gsrv_LDADD = $(NDTLIBS) $(I2UTILLIBS) $(I2UTILLIBDEPS) -lpthread $(ZLIB) $(JSONLIB) $(OPENSSL_LDFLAGS) $(OPENSSL_LIBS)
 web10gsrv_CPPFLAGS = '-DBASEDIR="$(ndtdir)"' $(OPENSSL_INCLUDES)
@@ -156,8 +156,8 @@ web10g_websocket_unit_tests_DEPENDENCIES = $(I2UTILLIBDEPS)
 web10g_testoptions_unit_tests_SOURCES = testoptions_unit_tests.c testoptions.c unit_testing.c \
                                  heuristics.c jsonutils.c logging.c mrange.c ndt_odbc.c ndtptestconstants.c \
                                  network.c protocol.c runningtest.c strlutils.c test_c2s_srv.c test_meta_srv.c \
-                                 test_mid_srv.c test_s2c_srv.c test_sfw_srv.c utils.c web100-pcap.c web100-util.c \
-                                 web100srv.c web10g-util.c websocket.c usage.c web100-admin.c
+                                 test_mid_srv.c test_s2c_srv.c test_sfw_srv.c testutils.c utils.c web100-pcap.c \
+                                 web100-util.c web100srv.c web10g-util.c websocket.c usage.c web100-admin.c
 web10g_testoptions_unit_tests_LDFLAGS = $(NDTLDFLAGS) $(I2UTILLDFLAGS)
 web10g_testoptions_unit_tests_LDADD = $(NDTLIBS) $(I2UTILLIBS) $(I2UTILLIBDEPS) -lpthread $(ZLIB) $(JSONLIB) $(OPENSSL_LDFLAGS) $(OPENSSL_LIBS)
 web10g_testoptions_unit_tests_CPPFLAGS ='-DBASEDIR="$(ndtdir)"' -DFORCE_WEB10G -DUSE_WEB100SRV_ONLY_AS_LIBRARY -Wall -Wno-unused-variable -Wno-unused-function $(OPENSSL_INCLUDES)
@@ -189,5 +189,5 @@ $(I2UTILLIBDEPS):
 
 EXTRA_DIST = clt_tests.h logging.h mrange.h network.h protocol.h testoptions.h test_sfw.h test_meta.h \
              troute.h tr-tree.h usage.h utils.h varinfo.h web100-admin.h web100srv.h ndt_odbc.h runningtest.h ndtptestconstants.h \
-             heuristics.h strlutils.h test_results_clt.h tests_srv.h jsonutils.h unit_testing.h websocket.h third_party/safe_iop.h
+             heuristics.h strlutils.h test_results_clt.h tests_srv.h testutils.h jsonutils.h unit_testing.h websocket.h third_party/safe_iop.h
 

--- a/src/test_c2s_srv.c
+++ b/src/test_c2s_srv.c
@@ -215,8 +215,9 @@ void packet_trace_emergency_shutdown(int *mon_pipe) {
  * @returns true if the fd is readable, false otherwise
  */
 int wait_for_readable_fd(int fd) {
-  fd_set rfd = {0};
+  fd_set rfd;
   struct timeval sel_tv = {0};
+  FD_ZERO(&rfd);
   FD_SET(fd, &rfd);
   sel_tv.tv_sec = 1;  // Wait for up to 1 second
   return (1 == select(fd + 1, &rfd, NULL, NULL, &sel_tv));

--- a/src/test_c2s_srv.c
+++ b/src/test_c2s_srv.c
@@ -23,7 +23,7 @@
 #include "jsonutils.h"
 #include "websocket.h"
 
-/** 
+/**
  * Use read or SSL_read in their raw forms. We want this to go as fast
  * as possible and we do not care about the contents of buff.
  * @param conn The Connection to use
@@ -180,6 +180,48 @@ void drain_old_clients(Connection* c2s_conns, int streamsNum, char* buff, size_t
   }
 }
 
+/** Makes the passed-in file descriptor into one that will not block.
+ * @param fd the file descriptor
+ * @returns non-zero if successful, zero on failure with errno as set by fcntl.
+ */
+int make_non_blocking(int fd) {
+  int flags;
+  flags = fcntl(fd, F_GETFL, NULL);
+  if (flags == -1) return 0;
+  return fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0;
+}
+
+/** Attempts to use the pipe to shutdown packet tracing. Will not block. After
+ * this function the file descriptors of the pipe are likely set to
+ * non-blocking. This should not affect any code because any shutdown messages
+ * sent should be the last usage of the pipe anyway.
+ * @param mon_pipe the pipe on which to send shutdown messages.
+ */
+void packet_trace_emergency_shutdown(int *mon_pipe) {
+  // Attempt to shut down the trace, but only after making sure that all
+  // attempts to write to the pipe will never block.
+  if (make_non_blocking(mon_pipe[1]) && make_non_blocking(mon_pipe[0])) {
+    stop_packet_trace(mon_pipe);
+  } else {
+    log_println(0,
+                "Couldn't make pipe non-blocking (errno=%d) and so was "
+                "unable to safely call stop_packet_trace",
+                errno);
+  }
+}
+
+/** Waits up to one second for the passed-in fd to become readable.
+ * @param fd the file descriptor to wait for
+ * @returns true if the fd is readable, false otherwise
+ */
+int wait_for_readable_fd(int fd) {
+  fd_set rfd = {0};
+  struct timeval sel_tv = {0};
+  FD_SET(fd, &rfd);
+  sel_tv.tv_sec = 1;  // Wait for up to 1 second
+  return (1 == select(fd + 1, &rfd, NULL, NULL, &sel_tv));
+}
+
 // How long to sleep to avoid a race condition.  This is a bad hack.
 // At 150k tests per day, this one sleep(2) wastes 83 hours of peoples'
 // lives every day.
@@ -239,6 +281,7 @@ int test_c2s(Connection *ctl, tcp_stat_agent *agent, TestOptions *testOptions,
   tcp_stat_group *group = NULL;
   /* The pipe that will return packet pair results */
   int mon_pipe[2];
+  int packet_trace_running = 0;
   pid_t c2s_childpid = 0;       // child process pids
   int msgretvalue, read_error;  // used during the "read"/"write" process
   int i;                  // used as loop iterator
@@ -246,6 +289,7 @@ int test_c2s(Connection *ctl, tcp_stat_agent *agent, TestOptions *testOptions,
   int retvalue = 0;
   int streamsNum = 1;
   int activeStreams = 1;
+  int local_errno;
 
   struct sockaddr_storage cli_addr[MAX_STREAMS];
   Connection c2s_conns[MAX_STREAMS];
@@ -516,20 +560,27 @@ int test_c2s(Connection *ctl, tcp_stat_agent *agent, TestOptions *testOptions,
       }
     }
 
-    // Get data collected from packet tracing into the C2S "ndttrace" file
-    memset(tmpstr, 0, 256);
-    for (i = 0; i < 5; i++) {
-      msgretvalue = read(mon_pipe[0], tmpstr, 128);
-      if ((msgretvalue == -1) && (errno == EINTR))
-        continue;
-      break;
-    }
+    packet_trace_running = wait_for_readable_fd(mon_pipe[0]);
 
-    if (strlen(tmpstr) > 5)
-      memcpy(meta.c2s_ndttrace, tmpstr, strlen(tmpstr));
-    // name of nettrace file passed back from pcap child
-    log_println(3, "--tracefile after packet_trace %s",
-                meta.c2s_ndttrace);
+    if (packet_trace_running) {
+      // Get data collected from packet tracing into the C2S "ndttrace" file
+      memset(tmpstr, 0, 256);
+      for (i = 0; i < 5; i++) {
+        msgretvalue = read(mon_pipe[0], tmpstr, 128);
+        if ((msgretvalue == -1) && (errno == EINTR))
+          continue;
+        break;
+      }
+
+      if (strlen(tmpstr) > 5)
+        memcpy(meta.c2s_ndttrace, tmpstr, strlen(tmpstr));
+      // name of nettrace file passed back from pcap child
+      log_println(3, "--tracefile after packet_trace %s",
+                  meta.c2s_ndttrace);
+    } else {
+      log_println(0, "Packet trace was unable to be created");
+      packet_trace_emergency_shutdown(mon_pipe);
+    }
   }
 
   log_println(5, "C2S test Parent thinks pipe() returned fd0=%d, fd1=%d",
@@ -661,28 +712,25 @@ int test_c2s(Connection *ctl, tcp_stat_agent *agent, TestOptions *testOptions,
   close_all_connections(c2s_conns, streamsNum);
   close(testOptions->c2ssockfd);
 
-  // Next, send speed-chk a flag to retrieve the data it collected.
-  // Skip this step if speed-chk isn't running.
-  if (getuid() == 0) {
+  if (packet_trace_running) {
     log_println(1, "Signal USR1(%d) sent to child [%d]", SIGUSR1,
                 c2s_childpid);
     testOptions->child1 = c2s_childpid;
     kill(c2s_childpid, SIGUSR1);
-    FD_ZERO(&rfd);
-    FD_SET(mon_pipe[0], &rfd);
-    sel_tv.tv_sec = 1;
-    sel_tv.tv_usec = 100000;
     i = 0;
 
     for (;;) {
-      msgretvalue = select(mon_pipe[0] + 1, &rfd, NULL, NULL,
-                           &sel_tv);
-      if ((msgretvalue == -1) && (errno == EINTR))
-        continue;
-      if (((msgretvalue == -1) && (errno != EINTR))
-          || (msgretvalue == 0)) {
+      FD_ZERO(&rfd);
+      FD_SET(mon_pipe[0], &rfd);
+      sel_tv.tv_sec = 1;
+      sel_tv.tv_usec = 100000;
+      msgretvalue = select(mon_pipe[0] + 1, &rfd, NULL, NULL, &sel_tv);
+      if (msgretvalue <= 0) {
+        local_errno = (msgretvalue == -1) ? errno : 0;
+        if (local_errno == EINTR) continue;
+        // Either a timeout or an error that wasn't EINTR...
         log_println(4, "Failed to read pkt-pair data from C2S flow, "
-                    "retcode=%d, reason=%d", msgretvalue, errno);
+                    "retcode=%d, reason=%d", msgretvalue, local_errno);
         snprintf(spds[(*spd_index)++],
                  sizeof(spds[*spd_index]),
                  " -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 0.0 0 0 0 0 0 -1");
@@ -690,12 +738,11 @@ int test_c2s(Connection *ctl, tcp_stat_agent *agent, TestOptions *testOptions,
                  sizeof(spds[*spd_index]),
                  " -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 0.0 0 0 0 0 0 -1");
         break;
-      }
-      /* There is something to read, so get it from the pktpair child.  If an interrupt occurs,
-       * just skip the read and go on
-       * RAC 2/8/10
-       */
-      if (msgretvalue > 0) {
+      } else {
+        /* There is something to read, so get it from the pktpair child.  If an
+         * interrupt occurs, just skip the read and go on
+         * RAC 2/8/10
+         */
         if ((msgretvalue = read(mon_pipe[0], spds[*spd_index],
                                 sizeof(spds[*spd_index]))) < 0) {
           snprintf(
@@ -706,11 +753,7 @@ int test_c2s(Connection *ctl, tcp_stat_agent *agent, TestOptions *testOptions,
         log_println(1, "%d bytes read '%s' from C2S monitor pipe",
                     msgretvalue, spds[*spd_index]);
         (*spd_index)++;
-        if (i++ == 1)
-          break;
-        sel_tv.tv_sec = 1;
-        sel_tv.tv_usec = 100000;
-        continue;
+        if (i++ == 1) break;
       }
     }
   }
@@ -720,8 +763,12 @@ int test_c2s(Connection *ctl, tcp_stat_agent *agent, TestOptions *testOptions,
                         testOptions->connection_flags, JSON_SINGLE_VALUE);
 
   //  Close opened resources for packet capture
-  if (getuid() == 0) {
+  if (packet_trace_running) {
+    // TODO: Determine whether this shutdown can be performed in a non-blocking
+    // manner, and if so then refactor packet_trace_emergency_shutdown to have
+    // better error handling and use that refactored and renamed function here.
     stop_packet_trace(mon_pipe);
+    packet_trace_running = 0;
   }
 
   // log end of C->S test

--- a/src/test_c2s_srv.c
+++ b/src/test_c2s_srv.c
@@ -15,6 +15,7 @@
 #include "ndtptestconstants.h"
 #include "utils.h"
 #include "testoptions.h"
+#include "testutils.h"
 #include "runningtest.h"
 #include "logging.h"
 #include "protocol.h"
@@ -178,49 +179,6 @@ void drain_old_clients(Connection* c2s_conns, int streamsNum, char* buff, size_t
     // Set up the FD_SET and activeStreams for the next select.
     activeStreams = connections_to_fd_set(c2s_conns, streamsNum, &rfd, &max_fd);
   }
-}
-
-/** Makes the passed-in file descriptor into one that will not block.
- * @param fd the file descriptor
- * @returns non-zero if successful, zero on failure with errno as set by fcntl.
- */
-int make_non_blocking(int fd) {
-  int flags;
-  flags = fcntl(fd, F_GETFL, NULL);
-  if (flags == -1) return 0;
-  return fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0;
-}
-
-/** Attempts to use the pipe to shutdown packet tracing. Will not block. After
- * this function the file descriptors of the pipe are likely set to
- * non-blocking. This should not affect any code because any shutdown messages
- * sent should be the last usage of the pipe anyway.
- * @param mon_pipe the pipe on which to send shutdown messages.
- */
-void packet_trace_emergency_shutdown(int *mon_pipe) {
-  // Attempt to shut down the trace, but only after making sure that all
-  // attempts to write to the pipe will never block.
-  if (make_non_blocking(mon_pipe[1]) && make_non_blocking(mon_pipe[0])) {
-    stop_packet_trace(mon_pipe);
-  } else {
-    log_println(0,
-                "Couldn't make pipe non-blocking (errno=%d) and so was "
-                "unable to safely call stop_packet_trace",
-                errno);
-  }
-}
-
-/** Waits up to one second for the passed-in fd to become readable.
- * @param fd the file descriptor to wait for
- * @returns true if the fd is readable, false otherwise
- */
-int wait_for_readable_fd(int fd) {
-  fd_set rfd;
-  struct timeval sel_tv = {0};
-  FD_ZERO(&rfd);
-  FD_SET(fd, &rfd);
-  sel_tv.tv_sec = 1;  // Wait for up to 1 second
-  return (1 == select(fd + 1, &rfd, NULL, NULL, &sel_tv));
 }
 
 // How long to sleep to avoid a race condition.  This is a bad hack.

--- a/src/testoptions.c
+++ b/src/testoptions.c
@@ -227,6 +227,7 @@ int recv_msg_plus_websocket(Connection* ctl, TestOptions* test_options,
   int64_t err;
   int received_length;
   if (readn_any(ctl, header, sizeof(header)) != sizeof(header)) {
+    log_println(3, "Failed to read %d bytes", sizeof(header));
     return EIO;
   }
   if (strncmp(header, "GET", 3) == 0) {
@@ -290,10 +291,12 @@ int initialize_tests(Connection *ctl, TestOptions *options, char *buff,
   if (recv_msg_plus_websocket(ctl, options, &msgType, msgValue, &msgLen)) {
     send_msg_any(ctl, MSG_ERROR, invalid_test_suite,
                  strlen(invalid_test_suite));
+    log_println(2, "recv_msg_plus_websocket failed");
     return (-1);
   }
   if (msgLen == -1) {
     snprintf(buff, buff_strlen, "Client timeout");
+    log_println(2, "Client timed out");
     return (-4);
   }
 

--- a/src/testoptions.c
+++ b/src/testoptions.c
@@ -132,8 +132,8 @@ snapWorker(void* arg) {
   while (1) {
     pthread_mutex_lock(&mainmutex);
     if (workerLoop) {
-      pthread_mutex_unlock(&mainmutex);
       pthread_cond_broadcast(&maincond);
+      pthread_mutex_unlock(&mainmutex);
       break;
     }
     pthread_mutex_unlock(&mainmutex);
@@ -277,7 +277,7 @@ int initialize_tests(Connection *ctl, TestOptions *options, char *buff,
   // char remhostarr[256], protologlocalarr[256];
   // char *remhost_ptr = get_remotehost();
 
-  assert(ctl.socket != -1);
+  assert(ctl->socket != -1);
   assert(options);
 
   memset(options->client_version, 0, sizeof(options->client_version));

--- a/src/testutils.c
+++ b/src/testutils.c
@@ -1,0 +1,48 @@
+#include <fcntl.h>
+#include <unistd.h>
+#include "logging.h"
+#include "testoptions.h"
+#include "testutils.h"
+
+/** Makes the passed-in file descriptor into one that will not block.
+ * @param fd the file descriptor
+ * @returns non-zero if successful, zero on failure with errno as set by fcntl.
+ */
+int make_non_blocking(int fd) {
+  int flags;
+  flags = fcntl(fd, F_GETFL, NULL);
+  if (flags == -1) return 0;
+  return fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0;
+}
+
+/** Attempts to use the pipe to shutdown packet tracing. Will not block. After
+ * this function the file descriptors of the pipe are likely set to
+ * non-blocking. This should not affect any code because any shutdown messages
+ * sent should be the last usage of the pipe anyway.
+ * @param mon_pipe the pipe on which to send shutdown messages.
+ */
+void packet_trace_emergency_shutdown(int *mon_pipe) {
+  // Attempt to shut down the trace, but only after making sure that all
+  // attempts to write to the pipe will never block.
+  if (make_non_blocking(mon_pipe[1]) && make_non_blocking(mon_pipe[0])) {
+    stop_packet_trace(mon_pipe);
+  } else {
+    log_println(0,
+                "Couldn't make pipe non-blocking (errno=%d) and so was "
+                "unable to safely call stop_packet_trace",
+                errno);
+  }
+}
+
+/** Waits up to one second for the passed-in fd to become readable.
+ * @param fd the file descriptor to wait for
+ * @returns true if the fd is readable, false otherwise
+ */
+int wait_for_readable_fd(int fd) {
+  fd_set rfd;
+  struct timeval sel_tv = {0};
+  FD_ZERO(&rfd);
+  FD_SET(fd, &rfd);
+  sel_tv.tv_sec = 1;  // Wait for up to 1 second
+  return (1 == select(fd + 1, &rfd, NULL, NULL, &sel_tv));
+}

--- a/src/testutils.h
+++ b/src/testutils.h
@@ -1,0 +1,5 @@
+/* These are helper methods which are used in multiple test_XXX_srv.c files. */
+
+int make_non_blocking(int fd);
+int wait_for_readable_fd(int fd);
+void packet_trace_emergency_shutdown(int *mon_pipe);

--- a/src/web100srv.c
+++ b/src/web100srv.c
@@ -664,7 +664,7 @@ int run_test(tcp_stat_agent *agent, Connection *ctl, TestOptions *testopt,
 
   // int n;  // temporary iterator variable --// commented out -> calc_linkspeed
   struct tcp_vars vars[MAX_STREAMS];
-  struct throughputSnapshot *s2c_ThroughputSnapshots, *c2s_ThroughputSnapshots;
+  struct throughputSnapshot *s2c_ThroughputSnapshots = NULL, *c2s_ThroughputSnapshots = NULL;
 
   int link = CANNOT_DETERMINE_LINK;  // local temporary variable indicative of
   // link speed. Transmitted but unused at client end , which has a similar
@@ -708,9 +708,9 @@ int run_test(tcp_stat_agent *agent, Connection *ctl, TestOptions *testopt,
   double timesec;         // Total test time in microseconds
   double packetloss_s2c;  // Packet loss as calculated from S->c tests.
   double RTOidle;         // Proportion of idle time spent waiting for packets
-  double s2cspd;          // average throughput as calculated by S->C test
-  double c2sspd;          // average throughput as calculated by C->S test
-  double s2c2spd;         // average throughput as calculated by midbox test
+  double s2cspd = 0;      // average throughput as calculated by S->C test
+  double c2sspd = 0;      // average throughput as calculated by C->S test
+  double s2c2spd = 0;     // average throughput as calculated by midbox test
   double realthruput;     // total send throughput in S->C
   double aspd = 0;
   float runave[4];
@@ -1635,6 +1635,7 @@ ndtchild *spawn_new_child(int listenfd, SSL_CTX *ssl_context) {
   I2AddrNodeName(cli_I2Addr, rmt_host, &rmt_host_strlen);
   log_println(4, "New connection received from 0x%x [%s] sockfd=%d.", cli_I2Addr,
               rmt_host, ctlsockfd);
+  I2AddrFree(cli_I2Addr);
   protolog_procstatus(getpid(), getCurrentTest(), CONNECT_TYPE, PROCESS_STARTED,
                       ctlsockfd);
 

--- a/src/web100srv.h
+++ b/src/web100srv.h
@@ -143,8 +143,6 @@ typedef struct portpair {
 // Structure defining NDT child process
 typedef struct ndtchild_s {
   int pid;  // process id
-  char addr[64];  // IP Address
-  char host[256];  // Hostname
   time_t stime;  // estimated start time of test
   time_t qtime;  // time when queued
   int running;  // Was this told to start running tests?

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -506,11 +506,17 @@ int initialize_websocket_connection(Connection* conn, unsigned int skip_bytes,
   char key[BASE64_SHA_DIGEST_LENGTH] = {0};
   int err;
   err = read_websocket_header(conn, skip_bytes, expected_protocol, key);
-  if (err != 0) return err;
+  if (err != 0) {
+    log_println(4, "error reading websocket header");
+    return err;
+  }
   // We have received a well-formed header. We should respond with a
   // well-formed response of our own.
   err = write_websocket_header(conn, expected_protocol, key);
-  if (err != 0) return err;
+  if (err != 0) {
+    log_println(4, "error writing websocket header");
+    return err;
+  }
   return 0;
 }
 


### PR DESCRIPTION
- If packet capture fails to start for whatever reason, then the whole client gets hung in a read. When enough clients are hung, then all incoming clients get queued, and the queue never gets any smaller. This adds a select() in front of the read() to ensure that the pipe becomes readable within a second. Thus, if the packet trace is unable to start, the test can still proceed without it.
- A one-line compiler warning fix for test_c2s.
- Fixing watchdog timer issues in web100srv.
- Making end-to-end unit tests less flaky by no longer just assuming that every port in the range [1024, 31024) is fine for the server to take as its own.
- Moved helper functions to testutils, so that they can be used by both c2s
and s2c. Used those new helper functions to fix a freezing error in s2c,
where the s2c test pauses until it hears back from the packet trace
engine, and so if the packet trace engine fails to start, then the s2c
test just freezes forever.
- eliminate a needless use of `strlen()`.
- One cleanup to an assert, and one fix that alleviates a crashing bug.
- Changes in response to valgrind worrying about uninitialized values and unsafe uses of pthread functions.
- SSL_accept no longer fails so much. This brings wss reliability up to ws reliability. Moves all accept()ing of the incoming socket into the child process.
- Cleanup of error-handling code.
- update the jquery version


