### PR TITLE
Enhance logging, error reporting.

### DIFF
--- a/HTML5-frontend/ndt-wrapper-ww.js
+++ b/HTML5-frontend/ndt-wrapper-ww.js
@@ -59,7 +59,13 @@ function startNDT(hostname, port, protocol, path, update_interval) {
         'cmd': 'onerror',
         'error_message': error_message
       });
-    }
+    },
+    'onlog': function(message) {
+      self.postMessage({
+        'cmd': 'onlog',
+        'message': message,
+      });
+    },
   };
 
   var client = new NDTjs(hostname, port, protocol, path, callbacks,


### PR DESCRIPTION
- Added the onlog callback to the ww. Can be used by whoever is
using the ww to ascertain progress, etc. In NDTjs the logger now
sends messages to that callback too.
- Add onopen,onerror and onclose event handlers to NDTjs. The first
two are trivial, but onclose tries to analyze the close event and
produce some useful messages, especially in the case of abnormal
websocket closure.