### PR TITLE
web100clt.c: make results parsing more robust

### DIFF
--- a/src/web100clt.c
+++ b/src/web100clt.c
@@ -149,15 +149,12 @@ void testResults(char tests, char *testresult_str, char* host) {
   }
 
   sysvar = strtok(testresult_str, " ");
-  sysval = strtok(NULL, "\n");
-  i = atoi(sysval);
-  save_int_values(sysvar, i);
-
   for (;;) {
-    sysvar = strtok(NULL, " ");
     if (sysvar == NULL)
       break;
     sysval = strtok(NULL, "\n");
+    if (sysval == NULL)
+      break;
     if (strchr(sysval, '.') == NULL) {
       i = atoi(sysval);
       save_int_values(sysvar, i);
@@ -167,6 +164,7 @@ void testResults(char tests, char *testresult_str, char* host) {
       save_dbl_values(sysvar, &j);
       log_println(7, "Stored %0.2f (%s) in %s", j, sysval, sysvar);
     }
+    sysvar = strtok(NULL, " ");
   }
 
   // CountRTT = 615596;


### PR DESCRIPTION
1) Do not assume that the first line we receive contains a space

2) Do not assume that the first line we receive contains an integer

3) Be robust to the case where input is an empty string

4) Do not assume that after the first token delimited by space we will find a second token delimited by newline

Tested under the following conditions:

a) `web100clt -n ndt.iupui.mlab1.trn01.measurement-lab.org` that sends back all variables and checked via printf() that the variables that are parsed by the new code are the ones received in resultstr

b) `web100clt -n neubot.mlab.mlab1.mil01.measurement-lab.org` that at the moment is running botticelli v0.0.5 (which is buggy and doesn't send any MSG_RESULTS messages) and make sure it does not crash

c) `web100clt -n neubot.mlab.mlab1.trn01.measurement-lab.org` that at the moment is running botticelli v0.0.6 (which sends a single dummy variable not considered by NDT) and make sure it doesn't crash

Note that a) and c) did not changed after this patch. What this patch changes is the behavior in case b).

[Edit: forgot to mention that, when I tested, in my NDT tree there was #216 applied, otherwise b) and c) would have failed due to segmentation fault caused by accessing a non-initialized string.]

xref: neubot/botticelli#18.