### PR TITLE
Exits with code 5 when --queueingtest detects queueing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,11 @@ script:
 # $TRAVIS_BUILD_DIR and $TRAVIS_COMMIT.
 - set -e
 - TEST_COMMIT=$( git rev-parse HEAD )
-- git clone --recursive https://github.com/m-lab/ndt-support.git
+- git clone https://github.com/m-lab/ndt-support.git
 - cd ndt-support
 - git config --file=.gitmodules submodule.ndt.url $TRAVIS_BUILD_DIR
 - git submodule sync
+- git submodule update --init --recursive
 - ( cd ndt && git checkout $TEST_COMMIT )
 - git commit -a -m 'Local commit of changes so "git submodule update" works'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,18 @@ script:
 # Checkout ndt-support repo and replace the ndt submodule with the current ndt
 # $TRAVIS_BUILD_DIR and $TRAVIS_COMMIT.
 - set -e
+# Clone ndt-support without cloning submodules.
 - git clone https://github.com/m-lab/ndt-support.git
 - cd ndt-support
+# Change the ndt-support submodule coniguration for ndt to point to the
+# $TRAVIS_BUILD_DIR (e.g. the current state of m-lab/ndt being tested by travis).
 - git config --file=.gitmodules submodule.ndt.url $TRAVIS_BUILD_DIR
+# Sync and update the new ndt-support submodule configuration, which clones all
+# submodules (now pulling ndt-support/ndt from $TRAVIS_BUILD_DIR).
 - git submodule sync
 - git submodule update --init --recursive
+# Checkout the current $TRAVIS_COMMIT and set the ndt-support submodule to
+# point to this commit.
 - ( cd ndt && git checkout $TRAVIS_COMMIT )
 - git commit -a -m 'Local commit of changes so "git submodule update" works'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
 # submodules (now pulling ndt-support/ndt from $TRAVIS_BUILD_DIR).
 - git submodule sync
 - git submodule update --init --recursive
-# Checkout the current $TRAVIS_COMMIT and set the ndt-support submodule to
+# Checkout the current $TRAVIS_COMMIT and set the ndt-support/ndt submodule to
 # point to this commit.
 - ( cd ndt && git checkout $TRAVIS_COMMIT )
 - git commit -a -m 'Local commit of changes so "git submodule update" works'

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,19 @@ services:
 
 script:
 
-# Temporarily use the git repo dev branch, instead of the google container registry.
-# TODO - update this once the GCR builder is up to date.
-- docker build -t build https://github.com/m-lab/builder.git#dev
-- docker run build /root/ndt_build_and_test.sh dev
+# Checkout ndt-support repo and replace the ndt submodule with the current ndt
+# $TRAVIS_BUILD_DIR and $TRAVIS_COMMIT.
+- git clone --recursive https://github.com/m-lab/ndt-support.git
+- cd ndt-support
+- git config --file=.gitmodules submodule.ndt.url $TRAVIS_BUILD_DIR
+- ( cd ndt && git checkout $TRAVIS_COMMIT )
+- git commit -a -m 'Local commit of changes so "git submodule update" works'
+
+# Build using the canonical build image and local ndt-support.
+- docker run -it -w /root/building
+    -v `pwd`:/root/building measurementlab/builder:production-1.0
+    bash -c "DISABLE_APPLET_SIGNING=1 ./package/slicebuild.sh iupui_ndt"
+- ls -lR build/slicebase-*
 
 #- docker pull gcr.io/mlab-pub/github-m-lab-builder:latest
 # Run basic unit tests that don't require web100

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,11 @@ script:
 
 # Checkout ndt-support repo and replace the ndt submodule with the current ndt
 # $TRAVIS_BUILD_DIR and $TRAVIS_COMMIT.
+- TEST_COMMIT=$( git rev-parse HEAD )
 - git clone --recursive https://github.com/m-lab/ndt-support.git
 - cd ndt-support
 - git config --file=.gitmodules submodule.ndt.url $TRAVIS_BUILD_DIR
-- ( cd ndt && git checkout $TRAVIS_COMMIT )
+- ( cd ndt && git checkout $TEST_COMMIT )
 - git commit -a -m 'Local commit of changes so "git submodule update" works'
 
 # Build using the canonical build image and local ndt-support.

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,12 @@ script:
 # Checkout ndt-support repo and replace the ndt submodule with the current ndt
 # $TRAVIS_BUILD_DIR and $TRAVIS_COMMIT.
 - set -e
-- TEST_COMMIT=$( git rev-parse HEAD )
 - git clone https://github.com/m-lab/ndt-support.git
 - cd ndt-support
 - git config --file=.gitmodules submodule.ndt.url $TRAVIS_BUILD_DIR
 - git submodule sync
 - git submodule update --init --recursive
-- ( cd ndt && git checkout $TEST_COMMIT )
+- ( cd ndt && git checkout $TRAVIS_COMMIT )
 - git commit -a -m 'Local commit of changes so "git submodule update" works'
 
 # Build using the canonical build image and local ndt-support.

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
 # Clone ndt-support without cloning submodules.
 - git clone https://github.com/m-lab/ndt-support.git
 - cd ndt-support
-# Change the ndt-support submodule coniguration for ndt to point to the
+# Change the ndt-support submodule configuration for ndt to point to the
 # $TRAVIS_BUILD_DIR (e.g. the current state of m-lab/ndt being tested by travis).
 - git config --file=.gitmodules submodule.ndt.url $TRAVIS_BUILD_DIR
 # Sync and update the new ndt-support submodule configuration, which clones all

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+# Build NDT and run unit tests.
+# * Uses docker build-tools container
+# * Executes unit tests within travis after build.
+
+dist: trusty
+language: ruby
+services:
+- docker
+
+script:
+
+# Temporarily use the git repo dev branch, instead of the google container registry.
+# TODO - update this once the GCR builder is up to date.
+- docker build -t build https://github.com/m-lab/builder.git#dev
+- docker run build /root/ndt_build_and_test.sh dev
+
+#- docker pull gcr.io/mlab-pub/github-m-lab-builder:latest
+# Run basic unit tests that don't require web100
+#- docker run gcr.io/mlab-pub/github-m-lab-builder /root/ndt_build_and_test.sh
+
+# TODO - collect coverage stats and export to coveralls.
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,12 @@ script:
 
 # Checkout ndt-support repo and replace the ndt submodule with the current ndt
 # $TRAVIS_BUILD_DIR and $TRAVIS_COMMIT.
+- set -e
 - TEST_COMMIT=$( git rev-parse HEAD )
 - git clone --recursive https://github.com/m-lab/ndt-support.git
 - cd ndt-support
 - git config --file=.gitmodules submodule.ndt.url $TRAVIS_BUILD_DIR
+- git submodule sync
 - ( cd ndt && git checkout $TEST_COMMIT )
 - git commit -a -m 'Local commit of changes so "git submodule update" works'
 

--- a/HTML5-frontend/style.css
+++ b/HTML5-frontend/style.css
@@ -32,13 +32,14 @@ a img {
 .header {
   margin: 10px;  
 }
-#warning-environment {
-  color: orange;
-  margin: 5px;
-}
-#warning-plugin, #warning-websocket {
+#no-websocket {
   color: red;
   margin: 5px;
+}
+#no-websocket {
+  color: red;
+  margin: 5px;
+  display: none;
 }
 .page {
   width: 640px;
@@ -119,7 +120,6 @@ h3 {
   background-color:gray;
   cursor: default;
 }
-
 
 /* Welcome page */
 

--- a/HTML5-frontend/widget.html
+++ b/HTML5-frontend/widget.html
@@ -12,7 +12,6 @@
     <script type="text/javascript" src="script.js"></script>
     <script type="text/javascript" src="ndt-browser-client.js"></script>
     <script type="text/javascript" src="ndt-wrapper.js"></script>
-    <script type="text/javascript" src="http://www.java.com/js/deployJava.js"></script>
     <script type="text/javascript">
     var simulate = false;
     var allowDebug = false;
@@ -27,25 +26,14 @@
 
     <p>The Network Diagnostic Tool (NDT) provides a sophisticated speed and diagnostic test. An NDT test reports more than just the upload and download speeds &mdash; it also attempts to determine what, if any, problems limited these speeds, differentiating between computer configuration and network infrastructure problems. While the diagnostic messages are most useful for expert users, they can also help novice users by allowing them to provide detailed trouble reports to their network&nbsp;administrator.</p>
 
-    <p>NDT can make use of either a Java plugin, or WebSockets to perform the test. Make sure that the method you choose is supported by your browser</p>
-    <div id="warning-environment">
-    </div>
-
-    <div id="warning-plugin">
-        <p>Selected plugin was not loaded properly. Make sure that you have proper plugin installed, and that it is not being blocked by your browser.</p>
-    </div>
-
-    <div id="warning-websocket">
-        <p>The WebSocket client currently in beta. Due to the nature of WebSocket support in various web browsers, the results may be notedly lower than those obtained with the Java plugin.</p>
-    </div>
-
-    <div>
-      <button id="javaButton" class="backendButton button" onclick="useJavaAsBackend()" type="button">Java</button>
-      <button id="websocketButton" class="backendButton button" onclick="useWebsocketAsBackend()" type="button">WebSockets<sup><small>Beta</small></sup></button>
-    </div>
+    <p>This NDT test uses <a href="https://en.wikipedia.org/wiki/WebSocket">WebSockets</a>. Most modern browsers should support running this test. If you are experiencing problems, make sure that your browser has javascript enabled and supports WebSockets.</p> 
 
     <div is="learn_more">
       <a href="http://software.internet2.edu/ndt/">Learn more about NDT</a> &ndash; <a href="http://www.measurementlab.net/">Learn more about Measurement Lab</a>
+    </div>
+
+    <div id="no-websocket">
+      <p>Your browser does not appear to support WebSockets. Please check your browser configuration or try a different browser.</p>
     </div>
 
     </div>
@@ -53,7 +41,7 @@
       Initializing...
     </div>
     <div class="controls">
-      <a href="#test" class="start button">Start Test</a>
+      <a href="#test" id="startButton" class="start button">Start Test</a>
     </div>
   </div>
   <div id="test" class="page">

--- a/configure.ac
+++ b/configure.ac
@@ -191,76 +191,31 @@ else
 fi
 
 
+#
+# configure I2util
+#
 AC_ARG_WITH(I2util,
 		AC_HELP_STRING([--with-I2util=<dir>],
 				[defaults to building I2util under NDT if exists]),
 		with_I2util=$withval, with_I2util=yes)		
 
-#
-# find I2util
-#
 I2UTILLDFLAGS=""
 I2UTILLIBS=""
 I2UTILLIBDEPS=""
 I2UTILLIBMAKE=""
 I2UTILINCS=""
 
-if test -n "$with_I2util" && test "$with_I2util" != "yes"; then
-	I2util_dir=${with_I2util}
-	case $I2util_dir in
-		/*) ;; # already an absolute path
-		*) I2util_dir="`pwd`/$I2util_dir" ;;
-	esac
-	I2util_include_dir=`dirname $with_I2util`/include
-	I2UTILINCS="-I$I2util_include_dir $I2UTILINCS"
-	I2UTILLDFLAGS="-L$I2util_dir $I2UTILLDFLAGS"
-	I2UTILLIBDEPS="$I2util_dir/libI2util.a"
+if test -d I2util/I2util; then
+	AC_CONFIG_SUBDIRS(I2util)
+	TOP_BUILD_DIRS="I2util $TOP_BUILD_DIRS"
+	I2util_dir='${top_srcdir}/I2util'
+	I2UTILINCS="-I$I2util_dir $I2UTILINCS"
+	I2UTILLDFLAGS="-L$I2util_dir/I2util $I2UTILLDFLAGS"
+	I2UTILLIBDEPS="$I2util_dir/I2util/libI2util.a"
+	I2UTILLIBMAKE="cd $I2util_dir; make"
+else
+	AC_MSG_FAILURE([I2util required to build NDT])
 fi
-
-# Save the old CFLAGS and LDFLAGS
-OLD_LDFLAGS="$LDFLAGS"
-OLD_CFLAGS="$CFLAGS"
-
-CFLAGS="$CFLAGS $I2UTILINCS"
-LDFLAGS="$CFLAGS $I2UTILLDFLAGS"
-
-AC_SEARCH_LIBS([I2AddrByNode],I2util, HAVE_I2UTIL_LIBS=1,HAVE_I2UTIL_LIBS=0)
-AC_CHECK_HEADERS([I2util/util.h I2util/conf.h], HAVE_I2UTIL_HEADERS=1,HAVE_I2UTIL_HEADERS=0)
-
-LDFLAGS="$OLD_LDFLAGS"
-CFLAGS="$OLD_CFLAGS"
-
-if test "$HAVE_I2UTIL_HEADERS" != "1" || test "$HAVE_I2UTIL_LIBS" != "1"; then
-	# now, check for sub-build/sub-configure
-	if test -d I2util/I2util; then
-		AC_CONFIG_SUBDIRS(I2util)
-		TOP_BUILD_DIRS="I2util $TOP_BUILD_DIRS"
-		I2util_dir='${top_srcdir}/I2util'
-		I2UTILINCS="-I$I2util_dir $I2UTILINCS"
-		I2UTILLDFLAGS="-L$I2util_dir/I2util $I2UTILLDFLAGS"
-		I2UTILLIBDEPS="$I2util_dir/I2util/libI2util.a"
-		I2UTILLIBMAKE="cd $I2util_dir; make"
-	else
-		AC_MSG_FAILURE([I2util required to build NDT])
-	fi
-
-        # Save the old CFLAGS and LDFLAGS
-	OLD_LDFLAGS="$LDFLAGS"
-	OLD_CFLAGS="$CFLAGS"
-
-        CFLAGS="$CFLAGS $I2UTILINCS"
-        LDFLAGS="$CFLAGS $I2UTILLDFLAGS"
-
-        AC_SEARCH_LIBS([I2AddrByNode],I2util, ,AC_MSG_ERROR([Couldn't find I2util library]))
-        AC_CHECK_HEADERS([I2util/util.h I2util/conf.h], ,AC_MSG_ERROR([Couldn't find I2util header files]), [AC_INCLUDES_DEFAULT])
-
-	LDFLAGS="$OLD_LDFLAGS"
-	CFLAGS="$OLD_CFLAGS"
-
-	I2UTILLIBS="$I2UTILLDFLAGS -lI2util"
-fi
-
-I2UTILLIBS="$I2UTILLDFLAGS -lI2util"
 
 AC_SUBST(I2UTILLDFLAGS)
 AC_SUBST(I2UTILLIBS)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -28,7 +28,7 @@ endif
 
 bin_PROGRAMS =
 sbin_PROGRAMS = $(ADD_FAKEWWW)
-noinst_PROGRAMS = 
+noinst_PROGRAMS =
 TESTS =
 
 if HAVE_WEB100

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -60,7 +60,6 @@ if HAVE_PCAP_H
 if HAVE_SSL
 if HAVE_JANSSON
 sbin_PROGRAMS += web100srv
-TESTS += web100srv_unit_tests
 endif
 endif
 endif

--- a/src/genplot.c
+++ b/src/genplot.c
@@ -27,6 +27,7 @@
 #include <sys/errno.h>
 #include <getopt.h>
 #include <sys/types.h>
+#include <web100.h>
 
 #include "web100srv.h"
 #include "usage.h"

--- a/src/logging.h
+++ b/src/logging.h
@@ -32,13 +32,21 @@ char* get_logfile();
 
 I2ErrHandle get_errhandle();
 
-// TODO: audit all the calls to log_print and log_println to maxmise ease of
+// TODO: audit all the calls to log_print and log_println to maximise ease of
 //       grepping through logs and eliminate the possibility of loglines that
 //       don't start with the timestamp/pid/level/file/line prefix.
 #define log_print log_println
 void log_println_impl(int lvl, const char* file, int line, const char* format, ...);
 #define log_println(lvl, ...) \
     log_println_impl((lvl), __FILE__, __LINE__, __VA_ARGS__)
+
+#define log_first_n(lvl, n, ...) { \
+    static int LOG_COUNT&&__LINE__ = n; \
+    if (LOG_COUNT&&__LINE__ > 0) { \
+      LOG_COUNT&&__LINE__--; \
+      log_println_impl((lvl), __FILE__, __LINE__, __VA_ARGS__); \
+    }}
+
 
 void log_free(void);
 void set_timestamp();

--- a/src/node_tests/ndt_client.js
+++ b/src/node_tests/ndt_client.js
@@ -354,7 +354,8 @@ function ndt_coordinator(sock) {
                     // server always replies with at least one SRV_QUEUE
                     // message, so we only care if the wait is more than 0.
                     if (argv['queueingtest'] && body.msg > 0) {
-                        die("Received SRV_QUEUE with wait time. Server is queueing.");
+                        log(DEBUG, "Received SRV_QUEUE with wait time. Server is queueing.");
+                        process.exit(5);
                     }
                 }
                 log(DEBUG, "Got SRV_QUEUE. Ignoring and waiting for MSG_LOGIN");

--- a/src/test_s2c_srv.c
+++ b/src/test_s2c_srv.c
@@ -11,6 +11,8 @@
 #include <pthread.h>
 #include <sys/times.h>
 #include <ctype.h>
+#include <web100.h>
+
 #include "tests_srv.h"
 #include "strlutils.h"
 #include "ndtptestconstants.h"

--- a/src/test_sfw_srv.c
+++ b/src/test_sfw_srv.c
@@ -8,6 +8,7 @@
 
 #include <assert.h>
 #include <pthread.h>
+#include <web100.h>
 
 #include "test_sfw.h"
 #include "logging.h"

--- a/src/testoptions.c
+++ b/src/testoptions.c
@@ -9,6 +9,7 @@
 #include <string.h>
 // #include <ctype.h>
 #include <pthread.h>
+#include <web100.h>
 
 #include "testoptions.h"
 #include "network.h"

--- a/src/web100-util.c
+++ b/src/web100-util.c
@@ -9,6 +9,7 @@
 #include <ctype.h>
 #include <time.h>
 #include <assert.h>
+#include <web100.h>
 
 #include "logging.h"
 #include "network.h"
@@ -821,7 +822,7 @@ int tcp_stat_get_data(tcp_stat_snap** snap, Connection* testsock, int streamsNum
  *
  *
  */
-int web100_rtt(int sock, web100_agent* agent, web100_connection* cn) {
+static int web100_rtt(int sock, web100_agent* agent, web100_connection* cn) {
   web100_var* var;
   char buf[32];
   web100_group* group;
@@ -938,8 +939,8 @@ int tcp_stat_autotune(int sock, tcp_stat_agent* agent, tcp_stat_connection cn) {
  * 					35 - cannot read value of RcvWinScale web100 variable.
  *
  */
-int tcp_stat_setbuff(int sock, tcp_stat_agent* agent, tcp_stat_connection cn,
-                     int autotune) {
+static int tcp_stat_setbuff(int sock, tcp_stat_agent* agent, tcp_stat_connection cn,
+                            int autotune) {
   web100_var* var;
   char buf[32];
   web100_group* group;
@@ -1108,7 +1109,7 @@ void tcp_stat_logvars_to_file(char* webVarsValuesLog, int connNum, struct tcp_va
   fclose(file);
 }
 
-tcp_stat_var agg_vars_sum(int connNum, int varId, struct tcp_vars* vars) {
+static tcp_stat_var agg_vars_sum(int connNum, int varId, struct tcp_vars* vars) {
   int i;
   tcp_stat_var varValue = *&((tcp_stat_var *)&vars[0])[varId];
   for (i = 1; i < connNum; ++i) {
@@ -1117,7 +1118,7 @@ tcp_stat_var agg_vars_sum(int connNum, int varId, struct tcp_vars* vars) {
   return varValue;
 }
 
-tcp_stat_var agg_vars_max(int connNum, int varId, struct tcp_vars* vars) {
+static tcp_stat_var agg_vars_max(int connNum, int varId, struct tcp_vars* vars) {
   int i;
   tcp_stat_var varValue = *&((tcp_stat_var *)&vars[0])[varId];
   for (i = 1; i < connNum; ++i) {
@@ -1128,7 +1129,7 @@ tcp_stat_var agg_vars_max(int connNum, int varId, struct tcp_vars* vars) {
   return varValue;
 }
 
-tcp_stat_var agg_vars_min(int connNum, int varId, struct tcp_vars* vars) {
+static tcp_stat_var agg_vars_min(int connNum, int varId, struct tcp_vars* vars) {
   int i;
   tcp_stat_var varValue = *&((tcp_stat_var *)&vars[0])[varId];
   for (i = 1; i < connNum; ++i) {
@@ -1139,7 +1140,7 @@ tcp_stat_var agg_vars_min(int connNum, int varId, struct tcp_vars* vars) {
   return varValue;
 }
 
-tcp_stat_var agg_vars_avg(int connNum, int varId, struct tcp_vars* vars) {
+static tcp_stat_var agg_vars_avg(int connNum, int varId, struct tcp_vars* vars) {
   int i;
   tcp_stat_var varValue = *&((tcp_stat_var *)&vars[0])[varId];
   for (i = 1; i < connNum; ++i) {
@@ -1326,7 +1327,7 @@ int CwndDecrease(char* logname, u_int32_t *dec_cnt,
  * @param nwords integer length (in bytes) of the header
  * @return unsigned short checksum
  */
-unsigned short csum(unsigned short *buff, int nwords) {
+static unsigned short csum(unsigned short *buff, int nwords) {
   /* generate a TCP/IP checksum for our packet */
 
   register int sum = 0;

--- a/src/web100clt.c
+++ b/src/web100clt.c
@@ -149,15 +149,12 @@ void testResults(char tests, char *testresult_str, char* host) {
   }
 
   sysvar = strtok(testresult_str, " ");
-  sysval = strtok(NULL, "\n");
-  i = atoi(sysval);
-  save_int_values(sysvar, i);
-
   for (;;) {
-    sysvar = strtok(NULL, " ");
     if (sysvar == NULL)
       break;
     sysval = strtok(NULL, "\n");
+    if (sysval == NULL)
+      break;
     if (strchr(sysval, '.') == NULL) {
       i = atoi(sysval);
       save_int_values(sysvar, i);
@@ -167,6 +164,7 @@ void testResults(char tests, char *testresult_str, char* host) {
       save_dbl_values(sysvar, &j);
       log_println(7, "Stored %0.2f (%s) in %s", j, sysval, sysvar);
     }
+    sysvar = strtok(NULL, " ");
   }
 
   // CountRTT = 615596;
@@ -924,6 +922,12 @@ int main(int argc, char *argv[]) {
   } else
     ptr = strtok_r(buff, " ", &strtokbuf);
 
+  /*
+   * Server may support less test types that we support. Hence, collect
+   * into this var _only_ the test types that were run successfully.
+   */
+  unsigned char run_tests = 0;
+
   // Run all tests requested, based on the ID.
   while (ptr) {
     if (check_int(ptr, &testId)) {
@@ -935,39 +939,45 @@ int main(int argc, char *argv[]) {
         if (test_mid_clt(ctlSocket, tests, host, conn_options, buf_size,
                          mid_resultstr, jsonSupport)) {
           log_println(0, "Middlebox test FAILED!");
-          tests &= (~TEST_MID);
+        } else {
+          run_tests |= TEST_MID;
         }
         break;
       case TEST_C2S:
         if (test_c2s_clt(ctlSocket, tests, host, conn_options, buf_size, &c2s_ThroughputSnapshots, jsonSupport, 0)) {
           log_println(0, "C2S throughput test FAILED!");
-          tests &= (~TEST_C2S);
+        } else {
+          run_tests |= TEST_C2S;
         }
         break;
       case TEST_C2S_EXT:
         if (test_c2s_clt(ctlSocket, tests, host, conn_options, buf_size, &c2s_ThroughputSnapshots, jsonSupport, 1)) {
           log_println(0, "Extended S2C throughput test FAILED!");
-          tests &= (~TEST_C2S_EXT);
+        } else {
+          run_tests |= TEST_C2S_EXT;
         }
         break;
       case TEST_S2C:
         if (test_s2c_clt(ctlSocket, tests, host, conn_options, buf_size,
                          resultstr, &s2c_ThroughputSnapshots, jsonSupport, 0)) {
           log_println(0, "S2C throughput test FAILED!");
-          tests &= (~TEST_S2C);
+        } else {
+          run_tests |= TEST_S2C;
         }
         break;
       case TEST_S2C_EXT:
         if (test_s2c_clt(ctlSocket, tests, host, conn_options, buf_size,
                          resultstr, &s2c_ThroughputSnapshots, jsonSupport, 1)) {
           log_println(0, "Extended S2C throughput test FAILED!");
-          tests &= (~TEST_S2C_EXT);
+        } else {
+          run_tests |= TEST_S2C_EXT;
         }
         break;
       case TEST_SFW:
         if (test_sfw_clt(ctlSocket, tests, host, conn_options, jsonSupport)) {
           log_println(0, "Simple firewall test FAILED!");
-          tests &= (~TEST_SFW);
+        } else {
+          run_tests |= TEST_SFW;
         }
         break;
       case TEST_META:
@@ -977,7 +987,8 @@ int main(int argc, char *argv[]) {
 
         if (test_meta_clt(ctlSocket, tests, host, conn_options, client_app_id, jsonSupport)) {
           log_println(0, "META test FAILED!");
-          tests &= (~TEST_META);
+        } else {
+          run_tests |= TEST_META;
         }
         break;
       default:
@@ -986,6 +997,9 @@ int main(int argc, char *argv[]) {
     }
     ptr = strtok_r(NULL, " ", &strtokbuf);
   }
+
+  /* Make sure we only process tests that were run */
+  tests = run_tests;
 
   /* get the final results from server.
    *

--- a/src/web100srv.h
+++ b/src/web100srv.h
@@ -323,8 +323,6 @@ int tcp_stat_autotune(int sock, tcp_stat_agent* agent, tcp_stat_connection cn);
 int tcp_stat_init(char *VarFileName);
 void tcp_stat_middlebox(int sock, tcp_stat_agent* agent, tcp_stat_connection cn, char *results_keys,
                         size_t results_keys_strlen, char *results_values, size_t results_strlen);
-int tcp_stat_setbuff(int sock, tcp_stat_agent* agent, tcp_stat_connection cn,
-                   int autotune);/* Not used so no web10g version */
 void tcp_stat_get_data_recv(int sock, tcp_stat_agent* agent,
                             tcp_stat_connection cn, int count_vars);
 


### PR DESCRIPTION
Currently, when the --queueingtest invocation of ndt_client.js detects queueing, it exits with code 1, which is the same code as any other error condition under which ndt_client.js might exit/fail. This PR simply sets the script to exit with code 5 when the --queueingtest flag was specified and queueing is detected. This will allow us to identify the queueing condition uniquely.