### PR TITLE
Update www.measurementlab.net links to HTTPS

### DIFF
--- a/HTML5-frontend/widget.html
+++ b/HTML5-frontend/widget.html
@@ -45,7 +45,7 @@
     </div>
 
     <div is="learn_more">
-      <a href="http://software.internet2.edu/ndt/">Learn more about NDT</a> &ndash; <a href="http://www.measurementlab.net/">Learn more about Measurement Lab</a>
+      <a href="http://software.internet2.edu/ndt/">Learn more about NDT</a> &ndash; <a href="https://www.measurementlab.net/">Learn more about Measurement Lab</a>
     </div>
 
     </div>
@@ -147,4 +147,3 @@
 
 </body>
 </html>
-

--- a/flash-client/src/NDTConstants.as
+++ b/flash-client/src/NDTConstants.as
@@ -14,7 +14,7 @@
 
 package  {
   public class NDTConstants {
-    public static const MLAB_SITE:String = "http://www.measurementlab.net";
+    public static const MLAB_SITE:String = "https://www.measurementlab.net";
 
     public static const CLIENT_VERSION:String = CONFIG::clientVersion;
     public static const EXPECTED_SERVER_VERSION:String = CONFIG::serverVersion;
@@ -250,4 +250,3 @@ package  {
         + "to obtain precise measurements.";
   }
 }
-


### PR DESCRIPTION
Per https://github.com/m-lab/m-lab.github.io/issues/166, M-Lab now prefers HTTPS links for its website. Should the URLs in this project be updated?